### PR TITLE
Improve travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ branches:
 
 install:
   - pip install -r requirements.txt
-  # required for optional dworp.plot
+  # matplotlib required for optional dworp.plot
   - pip install matplotlib
   - pip install -r test_requirements.txt
 before_script:
   - flake8 dworp
 script:
-  - nosetests --with-coverage
+  # only run coverage tests on a single build
+  - export RUN_COVERAGE=0
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then export RUN_COVERAGE=1; fi
+  - if [[ $RUN_COVERAGE == 1 ]]; then nosetests --with-coverage; fi
+  - if [[ $RUN_COVERAGE == 0 ]]; then nosetests; fi
 after_success:
-  - coveralls
+  - if [[ $RUN_COVERAGE == 1 ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   # only run coverage tests on a single build
   - export RUN_COVERAGE=0
   - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then export RUN_COVERAGE=1; fi
-  - if [[ $RUN_COVERAGE == 1 ]]; then nosetests --with-coverage; fi
+  - if [[ $RUN_COVERAGE == 1 ]]; then nosetests --with-coverage --cover-package=dworp; fi
   - if [[ $RUN_COVERAGE == 0 ]]; then nosetests; fi
 after_success:
   - if [[ $RUN_COVERAGE == 1 ]]; then coveralls; fi

--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ To run the tests, use pip to install nose (pip install nose) and then in the bas
 nosetests
 ```
 
+To get a report on unit test coverage:
+```bash
+nosetests --with-coverage --cover-package=dworp
+```
+
 Development
 -----------
 The code mostly follows the [PEP8 coding standard](https://www.python.org/dev/peps/pep-0008/).


### PR DESCRIPTION
1. Only run the code coverage once. Slightly speeds up the other builds and should stop the duplicate notifications from coveralls.